### PR TITLE
Add capture/upload clipbaord

### DIFF
--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -2,6 +2,7 @@
 // Copyright (C) Jake Gealer <jake@gealer.email> 2018.
 // Copyright (C) Rhys O'Kane <SunburntRock89@gmail.com> 2018.
 // Copyright (C) Leo Nesfield <leo@thelmgn.com> 2019.
+// Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
 
 // Defines the config.
 let { config: localConfig, saveConfig } = require("./config")

--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -140,6 +140,20 @@ async function runCapture(gif) {
 }
 global.runCapture = runCapture
 
+// Runs the clipboard capture
+async function runClipboardCapture() {
+    const filename = await capture.createCaptureFilename(false)
+    try {
+        const result = await capture.handleClipboard(filename, false)
+        capture.throwNotification(result)
+    } catch (err) {
+        await capture.logUpload(filename, false, null, null)
+        const translatedMessage = await i18n.getPoPhrase(`${err.message}`, "uploaders/exceptions")
+        dialog.showErrorBox("MagicCap", translatedMessage)
+    }
+}
+global.runClipboardCapture = runClipboardCapture
+
 // Opens the config.
 async function openConfig() {
     if (window) {
@@ -237,15 +251,17 @@ const createContextMenu = async() => {
             }
         )
     }
-    const i18nSelect = await i18n.getPoPhrase("Screen Capture", "app")
+    const i18nCapture = await i18n.getPoPhrase("Screen Capture", "app")
     const i18nGif = await i18n.getPoPhrase("GIF Capture", "app")
+    const i18nClipboard = await i18n.getPoPhrase("Clipboard Capture", "app")
     const i18nConfig = await i18n.getPoPhrase("Config", "app")
     const i18nUploadTo = await i18n.getPoPhrase("Upload to...", "app")
     const i18nShort = await i18n.getPoPhrase("Shorten Link...", "app")
     const i18nExit = await i18n.getPoPhrase("Exit", "app")
     const contextMenuTmp = [
-        { label: i18nSelect, type: "normal", click: async() => { await runCapture(false) } },
+        { label: i18nCapture, type: "normal", click: async() => { await runCapture(false) } },
         { label: i18nGif, type: "normal", click: async() => { await runCapture(true) } },
+        { label: i18nClipboard, type: "normal", click: async() => { await runClipboardCapture() } },
         { label: i18nConfig, type: "normal", click: openConfig },
         { label: i18nUploadTo, submenu: uploadDropdown },
         { label: i18nExit, type: "normal", role: "quit" },
@@ -291,6 +307,17 @@ const initialiseScript = async() => {
             dialog.showErrorBox("MagicCap", await i18n.getPoPhrase("The hotkey you gave was invalid.", "app"))
         }
     }
+
+    if (localConfig.clipboard_hotkey) {
+        try {
+            globalShortcut.register(localConfig.clipboard_hotkey, async () => {
+                thisShouldFixMacIssuesAndIdkWhy()
+                await runClipboardCapture()
+            })
+        } catch (_) {
+            dialog.showErrorBox("MagicCap", await i18n.getPoPhrase("The hotkey you gave was invalid.", "app"))
+        }
+    }
 }
 
 // Shows the link shortener.
@@ -322,6 +349,12 @@ ipcMain.on("hotkey-change", async(event, c) => {
             globalShortcut.register(c.gif_hotkey, async() => {
                 thisShouldFixMacIssuesAndIdkWhy()
                 await runCapture(true)
+            })
+        }
+        if (c.clipboard_hotkey) {
+            globalShortcut.register(c.clipboard_hotkey, async() => {
+                thisShouldFixMacIssuesAndIdkWhy()
+                await runClipboardCapture()
             })
         }
     } catch (_) {

--- a/magiccap/capture.js
+++ b/magiccap/capture.js
@@ -332,5 +332,6 @@ module.exports = class CaptureHandler {
         // Convert nativeimage to png buffer (clipboard doesn't support animated gifs)
         image = image.toPNG()
         // Upload/save
+        await this.fromBufferAndFilename(await this.getDefaultUploader(), image, filename)
     }
 }

--- a/magiccap/capture.js
+++ b/magiccap/capture.js
@@ -319,4 +319,18 @@ module.exports = class CaptureHandler {
         const i18nResult = await i18n.getPoPhrase("Image successfully captured.", "capture")
         return i18nResult
     }
+
+    // Handle from clipboard
+    static async handleClipboard(filename) {
+        // Attempt to fetch the nativeimage from the clipboard
+        let image = clipboard.readImage()
+        // If clipboard cannot be made an image, abort
+        if (image.isEmpty()) {
+            const noImagei18n = await i18n.getPoPhrase("The clipboard does not contain an image", "capture")
+            throw new Error(noImagei18n)
+        }
+        // Convert nativeimage to png buffer (clipboard doesn't support animated gifs)
+        image = image.toPNG()
+        // Upload/save
+    }
 }

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -217,6 +217,11 @@ async function runGifCapture() {
     await remote.getGlobal("runCapture")(true)
 }
 
+// Runs the Clipboard capture.
+async function runClipboardCapture() {
+    await remote.getGlobal("runClipboardCapture")()
+}
+
 
 // Shows the about page.
 function showAbout() {

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -2,6 +2,7 @@
 // Copyright (C) Jake Gealer <jake@gealer.email> 2018-2019.
 // Copyright (C) Rhys O'Kane <SunburntRock89@gmail.com> 2018.
 // Copyright (C) Leo Nesfield <leo@thelmgn.com> 2019.
+// Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
 
 // Handles escape to close.
 let activeModal

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -262,6 +262,7 @@ function showHotkeyConfig() {
 async function hotkeyConfigClose() {
     const text = document.getElementById("screenshotHotkey").value
     const gifText = document.getElementById("gifHotkey").value
+    const clipboardText = document.getElementById("clipboardHotkey").value
 
     if (config.hotkey !== text) {
         if (text === "") {
@@ -274,11 +275,21 @@ async function hotkeyConfigClose() {
     }
 
     if (config.gif_hotkey !== gifText) {
-        if (text === "") {
+        if (gifText === "") {
             config.gif_hotkey = null
             await saveConfig()
         } else {
             config.gif_hotkey = gifText
+            await saveConfig()
+        }
+    }
+
+    if (config.clipboard_hotkey !== clipboardText) {
+        if (clipboardText === "") {
+            config.clipboard_hotkey = null
+            await saveConfig()
+        } else {
+            config.clipboard_hotkey = clipboardText
             await saveConfig()
         }
     }
@@ -299,6 +310,7 @@ new Vue({
     data: {
         gifHotkey: config.gif_hotkey || "",
         screenshotHotkey: config.hotkey || "",
+        clipboardHotkey: config.clipboard_hotkey || "",
     },
 })
 

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -56,6 +56,9 @@
                         <li>
                             <a href="javascript:runGifCapture()">$GIF Capture$</a>
                         </li>
+                        <li>
+                            <a href="javascript:runClipboardCapture()">$Clipboard Capture$</a>
+                        </li>
                     </ul>
                 </aside>
             </aside>

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -315,6 +315,12 @@
                             <input class="input" type="text" id="gifHotkey" placeholder="$GIF Hotkey$" :value="gifHotkey">
                         </div>
                     </div>
+                    <div class="field">
+                        <label class="label" for="clipboardHotkey">$Clipboard Hotkey:$</label>
+                        <div class="control">
+                            <input class="input" type="text" id="clipboardHotkey" placeholder="$Clipboard Hotkey$" :value="clipboardHotkey">
+                        </div>
+                    </div>
                 </section>
             </div>
         </div>

--- a/magiccap/i18n/en/app.po
+++ b/magiccap/i18n/en/app.po
@@ -57,8 +57,16 @@ msgstr ""
 msgid "(Default)"
 msgstr ""
 
-# app.js:300
+# app.js:254
 msgid "Screen Capture"
+msgstr ""
+
+# app.js:255
+msgid "GIF Capture"
+msgstr ""
+
+# app.js:256
+msgid "Clipboard Capture"
 msgstr ""
 
 # app.js:308

--- a/magiccap/i18n/en/capture.po
+++ b/magiccap/i18n/en/capture.po
@@ -29,3 +29,7 @@ msgstr ""
 # capture.js:187
 msgid "Image successfully captured."
 msgstr ""
+
+# capture.js:303
+msgid "Clipboard does not contain an image."
+msgstr ""

--- a/magiccap/i18n/en/gui.po
+++ b/magiccap/i18n/en/gui.po
@@ -139,12 +139,28 @@ msgstr ""
 msgid "You can use {acceleratorDocs} in order to learn how to format your hotkey. Due to autosave causing possible issues when writing, it will be saved when this screen is closed."
 msgstr ""
 
-# gui/index.template.html:247
+# gui/index.template.html:307
 msgid "Screenshot Hotkey:"
 msgstr ""
 
-# gui/index.template.html:249
+# gui/index.template.html:309
 msgid "Screenshot Hotkey"
+msgstr ""
+
+# gui/index.template.html:313
+msgid "GIF Hotkey:"
+msgstr ""
+
+# gui/index.template.html:315
+msgid "GIF Hotkey"
+msgstr ""
+
+# gui/index.template.html:319
+msgid "Clipboard Hotkey:"
+msgstr ""
+
+# gui/index.template.html:321
+msgid "Clipboard Hotkey"
 msgstr ""
 
 # i18n/index.js:52


### PR DESCRIPTION
This PR enables the ability to upload/capture the current image on the user clipboard.
This supports PNG/JPEG officially and does not support GIFs (uses the first frame).
Hotkey configuration is available in the GUI, can be triggered through context menu or config sidebar.