### PR TITLE
Ability to open URL after upload + Allow copying image to clipboard when not saving locally

### DIFF
--- a/magiccap/capture.js
+++ b/magiccap/capture.js
@@ -8,7 +8,7 @@ const magicImports = require("magicimports")
 const gifman = require("gifman")
 const moment = magicImports("moment")
 const fsnextra = magicImports("fs-nextra")
-const { clipboard, nativeImage, Tray, dialog } = magicImports("electron")
+const { clipboard, nativeImage, Tray, dialog, shell } = magicImports("electron")
 const i18n = require("./i18n")
 const captureDatabase = magicImports("better-sqlite3")(`${require("os").homedir()}/magiccap.db`)
 const selector = require("./selector")
@@ -156,6 +156,9 @@ module.exports = class CaptureCore {
                             "Unknown clipboard action."
                         )
                     }
+                }
+                if (url && config.upload_open) {
+                    shell.openExternal(url)
                 }
                 await this._logUpload(this._filename, true, url, this._fp)
             } catch (e) {

--- a/magiccap/capture.js
+++ b/magiccap/capture.js
@@ -135,29 +135,27 @@ module.exports = class CaptureCore {
                     // We need to save this and tailor the return.
                     this._fp = `${config.save_path}${this._filename}`
                     await fsnextra.writeFile(this._fp, this.buffer)
-                    switch (config.clipboard_action) {
-                        case 1: {
-                            clipboard.writeImage(
-                                nativeImage.createFromBuffer(this.buffer)
-                            )
-                            break
-                        }
-                        case 2: {
-                            if (!url) {
-                                const noURLi18n = await i18n.getPoPhrase("URL not found to put into the clipboard. Do you have uploading on?", "capture")
-                                throw new Error(noURLi18n)
-                            }
-                            clipboard.writeText(url)
-                            break
-                        }
-                        default: {
-                            throw new Error(
-                                "Unknown clipboard action."
-                            )
-                        }
+                }
+                switch (config.clipboard_action) {
+                    case 1: {
+                        clipboard.writeImage(
+                            nativeImage.createFromBuffer(this.buffer)
+                        )
+                        break
                     }
-                } else if (url) {
-                    clipboard.writeText(url)
+                    case 2: {
+                        if (!url) {
+                            const noURLi18n = await i18n.getPoPhrase("URL not found to put into the clipboard. Do you have uploading on?", "capture")
+                            throw new Error(noURLi18n)
+                        }
+                        clipboard.writeText(url)
+                        break
+                    }
+                    default: {
+                        throw new Error(
+                            "Unknown clipboard action."
+                        )
+                    }
                 }
                 await this._logUpload(this._filename, true, url, this._fp)
             } catch (e) {

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -587,7 +587,8 @@ new Vue({
     el: "#uploaderConfigBody",
     data: {
         uploaders: importedUploaders,
-        checkUploadCheckbox: config.upload_capture,
+        checkUploaderUpload: config.upload_capture,
+        checkUploaderOpen: config.upload_open,
     },
     methods: {
         /**
@@ -644,11 +645,19 @@ new Vue({
             activeModal = "activeUploaderConfig"
         },
         /**
-         * Toggles a checkbox.
+         * Toggles the upload checkbox.
          */
-        toggleCheckbox() {
-            this.$set(this, "checkUploadCheckbox", !this.checkUploadCheckbox)
-            config.upload_capture = this.checkUploadCheckbox
+        toggleUpload() {
+            this.$set(this, "checkUploaderUpload", !this.checkUploaderUpload)
+            config.upload_capture = this.checkUploaderUpload
+            saveConfig()
+        },
+        /**
+         * Toggles the open checkbox.
+         */
+        toggleOpen() {
+            this.$set(this, "checkUploaderOpen", !this.checkUploaderOpen)
+            config.upload_open = this.checkUploaderOpen
             saveConfig()
         },
     },

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -276,7 +276,11 @@
                 </header>
                 <section class="modal-card-body" id="uploaderConfigBody">
                     <label class="input_container">$Upload files once they are captured.$
-                        <input type="checkbox" id="uploaderConfigCheckbox" :checked="checkUploadCheckbox" v-on:change="toggleCheckbox()">
+                        <input type="checkbox" id="uploaderUploadCheckbox" :checked="checkUploaderUpload" v-on:change="toggleUpload()">
+                        <span class="custom_input"></span>
+                    </label>
+                    <label class="input_container">$Open link in browser once uploaded.$
+                        <input type="checkbox" id="uploaderOpenCheckbox" :checked="checkUploaderOpen" v-on:change="toggleOpen()">
                         <span class="custom_input"></span>
                     </label>
                     <br/>

--- a/magiccap/i18n/en/gui.po
+++ b/magiccap/i18n/en/gui.po
@@ -161,8 +161,12 @@ msgstr ""
 msgid "Copy the image to the clipboard."
 msgstr ""
 
-# gui/index.template.html:194
+# gui/index.template.html:278
 msgid "Upload files once they are captured."
+msgstr ""
+
+# gui/index.template.html:282
+msgid "Open link in browser once uploaded."
 msgstr ""
 
 # gui/index.template.html:217


### PR DESCRIPTION
Adds the ability for the user to set MagicCap to open the URL of the uploaded capture in a browser. Checkbox setting available under uploader configuration.

This also resolves a bug whereby if you were only uploading and not saving the image locally, but had the clipboard action set to copy the image, it would in fact still copy the URL. It will now correctly copy the image.