### PR TITLE
Update the macOS context menu

### DIFF
--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -264,7 +264,7 @@ async function createContextMenu() {
     const i18nClipboard = await i18n.getPoPhrase("Clipboard Capture", "app")
     const i18nUploadTo = await i18n.getPoPhrase("Upload File to...", "app")
     const i18nShort = await i18n.getPoPhrase("Shorten Link...", "app")
-    const i18nPreferences = await i18n.getPoPhrase("Preferences", "app")
+    const i18nPreferences = await i18n.getPoPhrase("Preferences...", "app")
     const i18nQuit = await i18n.getPoPhrase("Quit", "app")
     const contextMenuTmp = [
         { label: i18nCapture, accelerator: config.hotkey, registerAccelerator: false, type: "normal", click: async() => { await runCapture(false) } },

--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -213,7 +213,7 @@ ipcMain.on("window-show", () => {
  */
 async function dropdownMenuUpload(uploader) {
     const selectFilei18n = await i18n.getPoPhrase("Select file...", "app")
-    await dialog.showOpenDialog({
+    await dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), {
         title: selectFilei18n,
         multiSelections: false,
         openDirectory: false,

--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -267,9 +267,9 @@ async function createContextMenu() {
     const i18nPreferences = await i18n.getPoPhrase("Preferences", "app")
     const i18nQuit = await i18n.getPoPhrase("Quit", "app")
     const contextMenuTmp = [
-        { label: i18nCapture, type: "normal", click: async() => { await runCapture(false) } },
-        { label: i18nGif, type: "normal", click: async() => { await runCapture(true) } },
-        { label: i18nClipboard, type: "normal", click: async() => { await runClipboardCapture() } },
+        { label: i18nCapture, accelerator: config.hotkey, registerAccelerator: false, type: "normal", click: async() => { await runCapture(false) } },
+        { label: i18nGif, accelerator: config.gif_hotkey, registerAccelerator: false, type: "normal", click: async() => { await runCapture(true) } },
+        { label: i18nClipboard, accelerator: config.clipboard_hotkey, registerAccelerator: false, type: "normal", click: async() => { await runClipboardCapture() } },
         { type: "separator" },
         { label: i18nUploadTo, submenu: uploadDropdown },
         // Link shortener inserted here if allowed
@@ -317,7 +317,10 @@ ipcMain.on("config-edit", async(event, data) => {
 ipcMain.on("test-uploader", async(event, data) => event.sender.send("test-uploader-res", await testUploader(uploaders[data])))
 
 // Handles the hotkey changing.
-ipcMain.on("hotkey-change", hotkeys)
+ipcMain.on("hotkey-change", async() => {
+    hotkeys()
+    await createContextMenu()
+})
 
 // The get uploaders IPC.
 ipcMain.on("get-uploaders", event => { event.returnValue = importedUploaders })

--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -262,7 +262,7 @@ async function createContextMenu() {
     const i18nCapture = await i18n.getPoPhrase("Screen Capture", "app")
     const i18nGif = await i18n.getPoPhrase("GIF Capture", "app")
     const i18nClipboard = await i18n.getPoPhrase("Clipboard Capture", "app")
-    const i18nUploadTo = await i18n.getPoPhrase("Upload to...", "app")
+    const i18nUploadTo = await i18n.getPoPhrase("Upload File to...", "app")
     const i18nShort = await i18n.getPoPhrase("Shorten Link...", "app")
     const i18nPreferences = await i18n.getPoPhrase("Preferences", "app")
     const i18nQuit = await i18n.getPoPhrase("Quit", "app")

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -306,38 +306,39 @@ async function hotkeyConfigClose() {
     const text = document.getElementById("screenshotHotkey").value
     const gifText = document.getElementById("gifHotkey").value
     const clipboardText = document.getElementById("clipboardHotkey").value
+    let changed = false
 
     if (config.hotkey !== text) {
+        changed = true
         if (text === "") {
             config.hotkey = null
-            await saveConfig()
         } else {
             config.hotkey = text
-            await saveConfig()
         }
     }
 
     if (config.gif_hotkey !== gifText) {
+        changed = true
         if (gifText === "") {
             config.gif_hotkey = null
-            await saveConfig()
         } else {
             config.gif_hotkey = gifText
-            await saveConfig()
         }
     }
 
     if (config.clipboard_hotkey !== clipboardText) {
+        changed = true
         if (clipboardText === "") {
             config.clipboard_hotkey = null
-            await saveConfig()
         } else {
             config.clipboard_hotkey = clipboardText
-            await saveConfig()
         }
     }
 
-    ipcRenderer.send("hotkey-change")
+    if (changed) {
+        await saveConfig()
+        ipcRenderer.send("hotkey-change")
+    }
 
     document.getElementById("hotkeyConfig").classList.remove("is-active")
 }

--- a/magiccap/i18n/en/app.po
+++ b/magiccap/i18n/en/app.po
@@ -74,7 +74,7 @@ msgid "Preferences"
 msgstr ""
 
 # app.js:309
-msgid "Upload to..."
+msgid "Upload File to..."
 msgstr ""
 
 # app.js:310

--- a/magiccap/i18n/en/app.po
+++ b/magiccap/i18n/en/app.po
@@ -70,7 +70,7 @@ msgid "Clipboard Capture"
 msgstr ""
 
 # app.js:308
-msgid "Preferences"
+msgid "Preferences..."
 msgstr ""
 
 # app.js:309


### PR DESCRIPTION
 - Show the hotkeys (accelerators) for each capture function in the context menu.
 - The `Upload to...` dropdown will now always show on top of the current application.
 - `Upload to...` has been renamed to `Upload File to...` for clarity.
 - `Preferences` has been renamed to `Preferences...` for consistency.