### PR TITLE
Convert Beta Updates tab to Updates, allow Check for Updates in tab

### DIFF
--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -331,6 +331,12 @@ ipcMain.on("hotkey-change", async() => {
     await createContextMenu()
 })
 
+// Allows for update checking in the gui
+ipcMain.on("check-for-updates", async event => {
+    await autoUpdateLoop.manualCheck()
+    event.sender.send("check-for-updates-done")
+})
+
 // The get uploaders IPC.
 ipcMain.on("get-uploaders", event => { event.returnValue = importedUploaders })
 

--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -277,6 +277,7 @@ async function createContextMenu() {
         // Link shortener inserted here if allowed
         { type: "separator" },
         { label: i18nPreferences, type: "normal", click: openConfig },
+        // Auto update here if enabled
         { label: i18nQuit, type: "normal", role: "quit" },
     ]
     if (AUTOUPDATE_ON) {

--- a/magiccap/gui/css/_modal.css
+++ b/magiccap/gui/css/_modal.css
@@ -7,6 +7,15 @@
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.4);
 }
 
+.modal .modal-card-body hr {
+    background: #4c5759;
+    margin: 1rem 0;
+}
+
+.modal .modal-card-body .modal-card-title {
+    margin-bottom: .5rem;
+}
+
 .modal .modal-background {
     background: rgba(10, 10, 10, .7);
 }

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -53,7 +53,6 @@ const i18n = require("./i18n")
 const mconf = require("./mconf")
 const Sentry = require("@sentry/electron")
 const { AUTOUPDATE_ON } = require("./build_info")
-const autoUpdateLoop = require(`${__dirname}/autoupdate.js`)
 
 // Initialises the Sentry SDK.
 Sentry.init({
@@ -204,8 +203,14 @@ function showBetaUpdates() {
 /**
  * Checks for updates.
  */
-function checkForUpdates() {
-    autoUpdateLoop.manualCheck()
+async function checkForUpdates(elm) {
+    elm.textContent = await i18n.getPoPhrase("Checking...", "gui")
+    elm.disabled = true
+    ipcRenderer.send("check-for-updates")
+    ipcRenderer.once("check-for-updates-done", async() => {
+        elm.textContent = await i18n.getPoPhrase("Check for Updates", "gui")
+        elm.disabled = false
+    })
 }
 
 // Handles new screenshots.

--- a/magiccap/gui/gui.js
+++ b/magiccap/gui/gui.js
@@ -53,6 +53,7 @@ const i18n = require("./i18n")
 const mconf = require("./mconf")
 const Sentry = require("@sentry/electron")
 const { AUTOUPDATE_ON } = require("./build_info")
+const autoUpdateLoop = require(`${__dirname}/autoupdate.js`)
 
 // Initialises the Sentry SDK.
 Sentry.init({
@@ -198,6 +199,13 @@ function showClipboardAction() {
 function showBetaUpdates() {
     activeModal = "betaUpdates"
     document.getElementById("betaUpdates").classList.add("is-active")
+}
+
+/**
+ * Checks for updates.
+ */
+function checkForUpdates() {
+    autoUpdateLoop.manualCheck()
 }
 
 // Handles new screenshots.

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -254,7 +254,7 @@
                     <a class="delete" aria-label="close" href="javascript:closeCurrentModal()"></a>
                 </header>
                 <section class="modal-card-body">
-                    <a class="button" href="javascript:checkForUpdates()">$Check for Updates$</a>
+                    <a class="button" href="#" onclick="checkForUpdates(this)">$Check for Updates$</a>
                     <hr/>
                     <p class="modal-card-title">$Beta Updates$</p>
                     <p>$Beta updates provide newer features and improved functionality, but before stable release some aspects may not be functional or may prove to be unstable.$</p>

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -250,10 +250,13 @@
             <div class="modal-background"></div>
             <div class="modal-card">
                 <header class="modal-card-head">
-                    <p class="modal-card-title">$Beta Updates$</p>
+                    <p class="modal-card-title">$Updates$</p>
                     <a class="delete" aria-label="close" href="javascript:closeCurrentModal()"></a>
                 </header>
                 <section class="modal-card-body">
+                    <a class="button" href="javascript:checkForUpdates()">$Check for Updates$</a>
+                    <hr/>
+                    <p class="modal-card-title">$Beta Updates$</p>
                     <p>$Beta updates provide newer features and improved functionality, but before stable release some aspects may not be functional or may prove to be unstable.$</p>
                     <br/>
                     <label class="input_container">$Only get stable updates.$

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -38,8 +38,8 @@
                         </li>
                         <li v-if="betaUpdates">
                             <a href="javascript:showBetaUpdates()"
-                               data-tooltip="$Toggle receiving beta updates before their stable release$">
-                                <i class="fas fa-cogs"></i> $Beta Updates$</a>
+                               data-tooltip="$Check for updates and toggle receiving beta updates$">
+                                <i class="fas fa-cogs"></i> $Updates$</a>
                         </li>
                         <!-- <li>
                             <a href="javascript:showMFLConfig()"

--- a/magiccap/i18n/en/gui.po
+++ b/magiccap/i18n/en/gui.po
@@ -48,7 +48,7 @@ msgid "Check for updates and toggle receiving beta updates"
 msgstr ""
 
 # gui/index.template.html:42
-# gui/index.template.html:206
+# gui/index.template.html:253
 msgid "Updates"
 msgstr ""
 
@@ -261,11 +261,19 @@ msgstr ""
 msgid "Beta updates provide newer features and improved functionality, but before stable release some aspects may not be functional or may prove to be unstable."
 msgstr ""
 
-# gui/index.template.html:211
+# gui/index.template.html:257
+msgid "Check for Updates"
+msgstr ""
+
+# gui/index.template.html:259
+msgid "Beta Updates"
+msgstr ""
+
+# gui/index.template.html:262
 msgid "Only get stable updates."
 msgstr ""
 
-# gui/index.template.html:212
+# gui/index.template.html:266
 msgid "Get stable and beta updates."
 msgstr ""
 

--- a/magiccap/i18n/en/gui.po
+++ b/magiccap/i18n/en/gui.po
@@ -262,7 +262,12 @@ msgid "Beta updates provide newer features and improved functionality, but befor
 msgstr ""
 
 # gui/index.template.html:257
+# gui/gui.js:211
 msgid "Check for Updates"
+msgstr ""
+
+# gui/gui.js:207
+msgid "Checking..."
 msgstr ""
 
 # gui/index.template.html:259

--- a/magiccap/i18n/en/gui.po
+++ b/magiccap/i18n/en/gui.po
@@ -44,12 +44,12 @@ msgid "Uploader Configuration"
 msgstr ""
 
 # gui/index.template.html:41
-msgid "Toggle receiving beta updates before their stable release"
+msgid "Check for updates and toggle receiving beta updates"
 msgstr ""
 
 # gui/index.template.html:42
 # gui/index.template.html:206
-msgid "Beta Updates"
+msgid "Updates"
 msgstr ""
 
 # gui/index.template.html:46


### PR DESCRIPTION
This PR converts the existing `Beta Updates` tab to a new `Updates` tab, which includes all the existing beta updates controls but with a new `Check for Updates` button, following this feature being added to the context menu.