### PR TITLE
Add tooltips to capture

### DIFF
--- a/magiccap/capture.js
+++ b/magiccap/capture.js
@@ -264,11 +264,13 @@ module.exports = class CaptureCore {
                     {
                         type: "selection",
                         name: "Blur",
+                        tooltip: await i18n.getPoPhrase("Blur a region within the capture", "capture"),
                         imageLocation: "blur.png",
                     },
                     {
                         type: "selection",
                         name: "__cap__",
+                        tooltip: await i18n.getPoPhrase("Select a region to capture", "capture"),
                         imageLocation: "crosshair.png",
                         active: true,
                     },

--- a/magiccap/gui/css/_menu.css
+++ b/magiccap/gui/css/_menu.css
@@ -8,35 +8,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     transition: all 300ms ease;
-    position: relative;
-}
-
-.menu .menu-list li > a:hover::before {
-    content: "";
-    position: absolute;
-    left: 100%;
-    top: 50%;
-    transform: translateY(-50%);
-    border-width: 8px 6px 8px 0;
-    border-style: solid;
-    border-color: transparent rgba(0, 0, 0, 0.9) transparent transparent;
-    z-index: 100;
-}
-
-.menu .menu-list li > a:hover::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    left: calc(100% + 6px);
-    top: 50%;
-    transform: translateY(-50%);
-    background: rgba(0, 0, 0, 0.9);
-    text-align: center;
-    color: #fff;
-    padding: 6px 4px;
-    font-size: 14px;
-    min-width: 80px;
-    border-radius: 5px;
-    pointer-events: none;
 }
 
 .menu .menu-list li > a > *[class*="fa"] {

--- a/magiccap/gui/css/_tooltip.css
+++ b/magiccap/gui/css/_tooltip.css
@@ -9,7 +9,10 @@
     content: "";
     position: absolute;
     border-style: solid;
+    border-color: transparent;
+    border-width: 8px;
     z-index: 100;
+    display: none;
 }
 
 [data-tooltip]:hover::after {
@@ -23,6 +26,7 @@
     min-width: 80px;
     border-radius: 5px;
     pointer-events: none;
+    z-index: 100;
     display: none;
 }
 
@@ -34,9 +38,62 @@
 }
 
 [data-tooltip][data-tooltip-position="right"]:hover::before {
+    display: block;
     left: 100%;
     top: 50%;
     transform: translateY(-50%);
-    border-width: 8px 6px 8px 0;
-    border-color: transparent rgba(0, 0, 0, 0.9) transparent transparent;
+    border-left-width: 0;
+    border-right-width: 6px;
+    border-right-color: rgba(0, 0, 0, 0.9);
+}
+
+[data-tooltip][data-tooltip-position="left"]:hover::after {
+    display: block;
+    right: calc(100% + 6px);
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+[data-tooltip][data-tooltip-position="left"]:hover::before {
+    display: block;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border-right-width: 0;
+    border-left-width: 6px;
+    border-left-color: rgba(0, 0, 0, 0.9);
+}
+
+[data-tooltip][data-tooltip-position="top"]:hover::after {
+    display: block;
+    left: 50%;
+    bottom: calc(100% + 6px);
+    transform: translateX(-50%);
+}
+
+[data-tooltip][data-tooltip-position="top"]:hover::before {
+    display: block;
+    left: 50%;
+    bottom: 100%;
+    transform: translateX(-50%);
+    border-bottom-width: 0;
+    border-top-width: 6px;
+    border-top-color: rgba(0, 0, 0, 0.9);
+}
+
+[data-tooltip][data-tooltip-position="bottom"]:hover::after {
+    display: block;
+    left: 50%;
+    top: calc(100% + 6px);
+    transform: translateX(-50%);
+}
+
+[data-tooltip][data-tooltip-position="bottom"]:hover::before {
+    display: block;
+    left: 50%;
+    top: 100%;
+    transform: translateX(-50%);
+    border-top-width: 0;
+    border-bottom-width: 6px;
+    border-bottom-color: rgba(0, 0, 0, 0.9);
 }

--- a/magiccap/gui/css/_tooltip.css
+++ b/magiccap/gui/css/_tooltip.css
@@ -23,7 +23,7 @@
     color: #fff;
     padding: 6px 4px;
     font-size: 14px;
-    min-width: 80px;
+    width: max-content;
     border-radius: 5px;
     pointer-events: none;
     z-index: 100;

--- a/magiccap/gui/css/_tooltip.css
+++ b/magiccap/gui/css/_tooltip.css
@@ -1,0 +1,42 @@
+/* This code is a part of MagicCap which is a MPL-2.0 licensed project.
+ * Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
+ */
+[data-tooltip] {
+    position: relative;
+}
+
+[data-tooltip]:hover::before {
+    content: "";
+    position: absolute;
+    border-style: solid;
+    z-index: 100;
+}
+
+[data-tooltip]:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    background: rgba(0, 0, 0, 0.9);
+    text-align: center;
+    color: #fff;
+    padding: 6px 4px;
+    font-size: 14px;
+    min-width: 80px;
+    border-radius: 5px;
+    pointer-events: none;
+    display: none;
+}
+
+[data-tooltip][data-tooltip-position="right"]:hover::after {
+    display: block;
+    left: calc(100% + 6px);
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+[data-tooltip][data-tooltip-position="right"]:hover::before {
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: 8px 6px 8px 0;
+    border-color: transparent rgba(0, 0, 0, 0.9) transparent transparent;
+}

--- a/magiccap/gui/css/main.css
+++ b/magiccap/gui/css/main.css
@@ -5,3 +5,4 @@
 @import "_modal.css";
 @import "_inputs.css";
 @import "_menu.css";
+@import "_tooltip.css";

--- a/magiccap/gui/index.html
+++ b/magiccap/gui/index.html
@@ -13,42 +13,50 @@
                     <ul class="menu-list">
                         <li>
                             <a href="javascript:showAbout()"
-                               data-tooltip="$View the version and authors$">
+                               data-tooltip="$View the version and authors$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-info"></i> $About$</a>
                         </li>
                         <li v-if="clipboardAction">
                             <a href="javascript:showClipboardAction()"
-                               data-tooltip="$Control what will be on your clipboard after capture$">
+                               data-tooltip="$Control what will be on your clipboard after capture$"
+                               data-tooltip-position="right">
                                 <i class="far fa-clipboard"></i> $Clipboard Action$</a>
                         </li>
                         <li v-if="fileConfig">
                             <a href="javascript:showFileConfig()"
-                               data-tooltip="$Configure capture file naming and local file saving$">
+                               data-tooltip="$Configure capture file naming and local file saving$"
+                               data-tooltip-position="right">
                                 <i class="far fa-file-alt"></i> $File Configuration$</a>
                         </li>
                         <li v-if="hotkeyConfig">
                             <a href="javascript:showHotkeyConfig()"
-                               data-tooltip="$Define hotkeys to trigger capture actions$">
+                               data-tooltip="$Define hotkeys to trigger capture actions$"
+                               data-tooltip-position="right">
                                 <i class="far fa-keyboard"></i> $Hotkey Settings$</a>
                         </li>
                         <li v-if="uploaderConfig">
                             <a href="javascript:showUploaderConfig()"
-                               data-tooltip="$Enable uploading captures and configure the upload target$">
+                               data-tooltip="$Enable uploading captures and configure the upload target$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-upload"></i> $Uploader Settings$</a>
                         </li>
                         <li v-if="betaUpdates">
                             <a href="javascript:showBetaUpdates()"
-                               data-tooltip="$Check for updates and toggle receiving beta updates$">
+                               data-tooltip="$Check for updates and toggle receiving beta updates$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-cogs"></i> $Updates$</a>
                         </li>
                         <!-- <li>
                             <a href="javascript:showMFLConfig()"
-                               data-tooltip="$Configure the language of the application$">
+                               data-tooltip="$Configure the language of the application$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-globe-europe"></i> $Change Language$</a>
                         </li> -->
                         <li v-if="toggleTheme">
                             <a href="javascript:toggleTheme()"
-                               data-tooltip="$Switch between light and dark mode$">
+                               data-tooltip="$Switch between light and dark mode$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-palette"></i> $Toggle Theme$</a>
                         </li>
 
@@ -56,22 +64,26 @@
 
                         <li v-if="shortener">
                             <a href="javascript:showShortener()"
-                               data-tooltip="$Shorten links using s.magiccap.me$">
+                               data-tooltip="$Shorten links using s.magiccap.me$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-link"></i> $Link Shortener$</a>
                         </li>
                         <li>
                             <a href="javascript:runCapture()"
-                               data-tooltip="$Run the screen capture tool in MagicCap$">
+                               data-tooltip="$Run the screen capture tool in MagicCap$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-camera"></i> $Screen Capture$</a>
                         </li>
                         <li>
                             <a href="javascript:runGifCapture()"
-                               data-tooltip="$Capture a GIF recording of the screen$">
+                               data-tooltip="$Capture a GIF recording of the screen$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-video"></i> $GIF Capture$</a>
                         </li>
                         <li>
                             <a href="javascript:runClipboardCapture()"
-                               data-tooltip="$Capture the current image on your clipboard$">
+                               data-tooltip="$Capture the current image on your clipboard$"
+                               data-tooltip-position="right">
                                 <i class="fas fa-clipboard-check"></i> $Clipboard Capture$</a>
                         </li>
                     </ul>

--- a/magiccap/i18n/en/capture.po
+++ b/magiccap/i18n/en/capture.po
@@ -33,3 +33,11 @@ msgstr ""
 # capture.js:303
 msgid "Clipboard does not contain an image."
 msgstr ""
+
+# capture.js:267
+msgid "Blur a region within the capture"
+msgstr ""
+
+# capture.js:273
+msgid "Select a region to capture"
+msgstr ""

--- a/magiccap/selector/index.js
+++ b/magiccap/selector/index.js
@@ -1,6 +1,7 @@
 // This code is a part of MagicCap which is a MPL-2.0 licensed project.
 // Copyright (C) Jake Gealer <jake@gealer.email> 2019.
 // Copyright (C) Rhys O'Kane <SunburntRock89@gmail.com> 2019.
+// Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
 
 // Defines the required imports.
 const { ipcMain, BrowserWindow } = require("electron")
@@ -96,6 +97,9 @@ freezeServer.get("/selector/icons/:icon", (req, res) => {
 })
 freezeServer.get("/root/:file", (req, res) => {
     res.sendFile(`${__dirname}/${path.basename(req.params.file)}`)
+})
+freezeServer.get("/tooltips", (req, res) => {
+    res.sendFile(`${path.join(__dirname, "..")}/gui/css/_tooltip.css`)
 })
 let xyImageMap = new Map()
 freezeServer.get("/selector/magnify", async(req, res) => {

--- a/magiccap/selector/selector.html
+++ b/magiccap/selector/selector.html
@@ -1,6 +1,8 @@
 <html>
     <head>
         <style>
+            @import url("/tooltips");
+
             html * {
                 cursor: none
             }
@@ -49,6 +51,7 @@
 
             #UploaderProperties {
                 text-align: center;
+                font-family: "Roboto", sans-serif;
                 margin-top: 20px;
                 font-size: 0;
             }
@@ -67,7 +70,7 @@
             #cursorX, #cursorY {
                 position: absolute;
                 pointer-events: none;
-                z-index: 0;
+                z-index: 50;
                 background: rgba(0, 0, 0, 0.4);
                 border: 1px solid rgba(255, 255, 255, 0.05)
             }

--- a/magiccap/selector/selector.js
+++ b/magiccap/selector/selector.js
@@ -1,5 +1,6 @@
 // This code is a part of MagicCap which is a MPL-2.0 licensed project.
 // Copyright (C) Jake Gealer <jake@gealer.email> 2019.
+// Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
 
 // Requires Electron.
 const electron = require("electron")
@@ -284,7 +285,8 @@ if (payload.buttons && payload.mainDisplay) {
     for (const buttonId in payload.buttons) {
         const button = payload.buttons[buttonId]
         propertyStr += `
-            <a href="javascript:invokeButton(${buttonId})" style="cursor: default;">
+            <a href="javascript:invokeButton(${buttonId})" style="cursor: default;"
+               data-tooltip="${button.tooltip}" data-tooltip-position="bottom">
                 <img class="clickable-property${button.active ? " selected" : ""}" src="/selector/icons/${button.imageLocation}">
             </a>
         `


### PR DESCRIPTION
Add tooltips to the capture tools through a new property of each button.
Also moves tooltips to their own css file and writes the rules for all four tooltip positions.