### PR TITLE
Capture tools styling

### DIFF
--- a/magiccap/selector/index.js
+++ b/magiccap/selector/index.js
@@ -142,11 +142,12 @@ freezeServer.listen(freezeServerPort, "127.0.0.1")
  */
 const spawnWindows = (displays, primaryId) => {
     const windows = []
+    const captureDev = process.argv.includes("-captureDev")
     for (let index in displays) {
         const i = displays[index]
         let win = new BrowserWindow({
             frame: false,
-            alwaysOnTop: true,
+            alwaysOnTop: !captureDev,
             show: false,
             width: i.bounds.width,
             height: i.bounds.height,
@@ -162,6 +163,7 @@ const spawnWindows = (displays, primaryId) => {
             win.setFullScreen(true)
             win.show()
             win.focus()
+            if (captureDev) win.webContents.openDevTools()
         })
         win.loadURL(`http://127.0.0.1:${freezeServerPort}/selector/render?uuid=${uuid}&primary=${primary ? "1" : "0"}&display=${index}&bounds=${encodeURIComponent(JSON.stringify(bounds))}&key=${screenshotServerKey}`)
         win.setVisibleOnAllWorkspaces(true)

--- a/magiccap/selector/selector.html
+++ b/magiccap/selector/selector.html
@@ -9,6 +9,7 @@
             }
 
             html * {
+                user-select: none;
                 cursor: none
             }
 

--- a/magiccap/selector/selector.html
+++ b/magiccap/selector/selector.html
@@ -17,6 +17,11 @@
                 border: 0;
                 padding: 0;
                 margin: 0;
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
                 background-image: %IMAGE_URL%;
             }
 

--- a/magiccap/selector/selector.html
+++ b/magiccap/selector/selector.html
@@ -130,6 +130,14 @@
                 border-radius: 8px;
                 font-family: "Roboto";
             }
+
+            #magnify, #position, #cursorX, #cursorY, #UploaderProperties {
+                opacity: 0;
+            }
+
+            body:hover #magnify, body:hover #position, body:hover #cursorX, body:hover #cursorY, body:hover #UploaderProperties {
+                opacity: 1;
+            }
         </style>
     </head>
     <body>

--- a/magiccap/selector/selector.html
+++ b/magiccap/selector/selector.html
@@ -3,6 +3,11 @@
         <style>
             @import url("/tooltips");
 
+            @font-face {
+                font-family: "Roboto";
+                src: url("/selector/font") format("truetype");
+            }
+
             html * {
                 cursor: none
             }
@@ -47,6 +52,7 @@
                 background: rgba(0, 0, 0, 0.4);
                 margin: 0;
                 padding: 2px 4px;
+                border-radius: 2px;
             }
 
             #UploaderProperties {
@@ -106,17 +112,17 @@
                 align-items: center;
                 justify-content: center;
                 position: absolute;
-                background-color: black;
+                background: rgba(0, 0, 0, 0.4);
+                border: 1px solid #fff;
                 z-index: -2;
             }
 
-            @font-face {
-                font-family: "Roboto";
-                src: url("/selector/font") format("truetype");
-            }
-
             .selection-text {
-                color: white;
+                color: #fff;
+                background: rgba(0, 0, 0, 0.8);
+                margin: 0;
+                padding: 4px 16px;
+                border-radius: 8px;
                 font-family: "Roboto";
             }
         </style>

--- a/magiccap/selector/selector.js
+++ b/magiccap/selector/selector.js
@@ -285,7 +285,7 @@ function invokeButton(buttonId) {
 }
 
 // Handles displaying the buttons.
-if (payload.buttons && payload.mainDisplay) {
+if (payload.buttons) {
     let propertyStr = ""
     for (const buttonId in payload.buttons) {
         const button = payload.buttons[buttonId]

--- a/magiccap/selector/selector.js
+++ b/magiccap/selector/selector.js
@@ -235,6 +235,11 @@ document.body.onmouseup = async e => {
             </h1>
         `
         document.body.appendChild(selectionBlackness)
+        element.style.top = "-10px"
+        element.style.left = "-10px"
+        element.style.width = "0px"
+        element.style.height = "0px"
+        element.style.boxShadow = "none"
     }
 }
 

--- a/magiccap/selector/selector.js
+++ b/magiccap/selector/selector.js
@@ -87,9 +87,9 @@ async function moveSelectorMagnifier() {
     document.getElementById("positions").textContent = `X: ${x} | Y: ${y}`
 
     const cursorX = document.getElementById("cursorX")
-    cursorX.style.left = x
+    cursorX.style.left = x - (cursorX.getBoundingClientRect().width / 2)
     const cursorY = document.getElementById("cursorY")
-    cursorY.style.top = payload.bounds.height - (payload.bounds.height - y)
+    cursorY.style.top = payload.bounds.height - (payload.bounds.height - y) - (cursorY.getBoundingClientRect().height / 2)
 
     const fetchReq = await fetch(`http://127.0.0.1:${payload.server.port}/selector/magnify?key=${payload.server.key}&display=${payload.display}&height=25&width=25&x=${x}&y=${y}`)
     const urlPart = URL.createObjectURL(await fetchReq.blob())


### PR DESCRIPTION
 - Changes the styling of the blur selection regions to be cleaner and more consistent with the rest of the capture/selection process
 - Resolves the menubar issue on macOS where you couldn't select a capture region in the menubar
 - Capture tool buttons are now on all windows, they will only show in the window where the cursor currently is (hovering)
 - Fixes the positioning of the cursor crosshair (previous PR) so that they are correctly centered on the pointer position
 - Removes the ability to select anything (text selection on drag), as you could select the capture tool buttons before