### PR TITLE
Make modals part of the main content, not popups

### DIFF
--- a/src/gui/css/components/base.css
+++ b/src/gui/css/components/base.css
@@ -60,6 +60,10 @@ a, button, .button, .delete {
     content: "\f35d";
 }
 
+table.table {
+    background: transparent;
+}
+
 table.hidden {
     display: none;
 }

--- a/src/gui/css/components/base.css
+++ b/src/gui/css/components/base.css
@@ -59,3 +59,7 @@ a, button, .button, .delete {
     opacity: 0.6;
     content: "\f35d";
 }
+
+table.hidden {
+    display: none;
+}

--- a/src/gui/css/components/modal.css
+++ b/src/gui/css/components/modal.css
@@ -4,6 +4,7 @@
 
 .modal {
     margin: 0 0 0 15%;
+    z-index: -1; /* Allow tooltips in sidebar to work */
 }
 
 .modal .modal-card {
@@ -19,11 +20,6 @@
 
 .modal .modal-card-body .modal-card-title {
     margin-bottom: .5rem;
-}
-
-.modal .modal-background {
-    /*background: rgba(10, 10, 10, .7);*/
-    background: #282f2f;
 }
 
 .modal .delete {

--- a/src/gui/css/components/modal.css
+++ b/src/gui/css/components/modal.css
@@ -2,9 +2,14 @@
  * Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
  */
 
+.modal {
+    margin: 0 0 0 15%;
+}
+
 .modal .modal-card {
     border-radius: 10px;
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.4);
+    /*box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.4);*/
+    box-shadow: none;
 }
 
 .modal .modal-card-body hr {
@@ -17,7 +22,8 @@
 }
 
 .modal .modal-background {
-    background: rgba(10, 10, 10, .7);
+    /*background: rgba(10, 10, 10, .7);*/
+    background: #282f2f;
 }
 
 .modal .delete {

--- a/src/gui/css/dark.css
+++ b/src/gui/css/dark.css
@@ -4,6 +4,10 @@
 @import "bulmaswatch/darkly/bulmaswatch.min.css";
 @import "main.css";
 
+body {
+    color: #fff;
+}
+
 ::-webkit-scrollbar {
     background-color: #343434;
 }
@@ -26,6 +30,10 @@
     color: #fff;
 }
 
-table.table {
-    background: rgba(255, 255, 255, 0.1);
+.column,
+.modal-background,
+.modal-card-foot,
+.modal-card-head,
+.modal-card-body {
+    background: #282f2f;
 }

--- a/src/gui/css/light.css
+++ b/src/gui/css/light.css
@@ -4,6 +4,10 @@
 @import "bulmaswatch/default/bulmaswatch.min.css";
 @import "main.css";
 
+body {
+    color: #000;
+}
+
 ::-webkit-scrollbar {
     background-color: #efefef;
 }
@@ -26,6 +30,10 @@
     color: #343434;
 }
 
-table.table {
-    background: rgba(0, 0, 0, 0.1);
+.column,
+.modal-background,
+.modal-card-foot,
+.modal-card-head,
+.modal-card-body {
+    background: #ededed;
 }

--- a/src/gui/gui.js
+++ b/src/gui/gui.js
@@ -553,7 +553,7 @@ const activeUploaderConfig = new Vue({
          */
         closeActiveConfig() {
             this.$set(this, "exception", "")
-            document.getElementById("activeUploaderConfig").classList.remove("is-active")
+            closeCurrentModal()
         },
         /**
          * Validates the config.

--- a/src/gui/gui.js
+++ b/src/gui/gui.js
@@ -8,9 +8,12 @@
 let activeModal
 
 /**
- * Closes the active modal if there is one (and hides all others)
+ * Closes all active modals with correct dismiss actions & shows capture content
  */
 function closeCurrentModal() {
+    // Show table
+    document.getElementById("mainTable").classList.remove("hidden")
+
     // Find all active modals
     const all = document.querySelectorAll(".modal.is-active")
     all.forEach(div => {
@@ -24,6 +27,25 @@ function closeCurrentModal() {
 
     // Remove activeModal if was set
     if (activeModal) activeModal = undefined
+}
+
+/**
+ * Shows a new modal based on ID (hides existing modals & capture content)
+ */
+function showModal(id) {
+    // Get the modal
+    const modal = document.getElementById(id)
+    if (!modal) return
+
+    // Close existing modals
+    closeCurrentModal()
+
+    // Show the modal
+    modal.classList.add("is-active")
+    activeModal = id
+
+    // Hide captures table
+    document.getElementById("mainTable").classList.add("hidden")
 }
 
 // Allow devtools to be opened (placing this at the top just in case something breaks whilst loading)
@@ -194,18 +216,14 @@ new Vue({
  * Shows the clipboard action settings page.
  */
 function showClipboardAction() {
-    closeCurrentModal()
-    activeModal = "clipboardAction"
-    document.getElementById("clipboardAction").classList.add("is-active")
+    showModal("clipboardAction")
 }
 
 /**
  * Shows the beta updates settings page.
  */
 function showBetaUpdates() {
-    closeCurrentModal()
-    activeModal = "betaUpdates"
-    document.getElementById("betaUpdates").classList.add("is-active")
+    showModal("betaUpdates")
 }
 
 /**
@@ -251,9 +269,7 @@ async function runClipboardCapture() {
  * Shows the about page.
  */
 function showAbout() {
-    closeCurrentModal()
-    activeModal = "about"
-    document.getElementById("about").classList.add("is-active")
+    showModal("about")
 }
 
 /**
@@ -277,7 +293,6 @@ function safeConfig() {
  * Shows the debug information page.
  */
 function showDebug() {
-    closeCurrentModal()
     // Generate debug information
     document.getElementById("debugInfo").textContent = `MagicCap Version: ${remote.app.getVersion()}
 System OS: ${os.type()} ${os.release()} / Platform: ${process.platform}
@@ -285,8 +300,7 @@ Installation ID: ${config.install_id}
 Config: ${JSON.stringify(safeConfig())}
 liteTouch Config: ${global.liteTouchConfig}`
     // Show
-    activeModal = "debug"
-    document.getElementById("debug").classList.add("is-active")
+    showModal("debug")
 }
 
 /**
@@ -307,18 +321,14 @@ async function copyDebug() {
  * Shows the file config.
  */
 function showFileConfig() {
-    closeCurrentModal()
-    activeModal = "fileConfig"
-    document.getElementById("fileConfig").classList.add("is-active")
+    showModal("fileConfig")
 }
 
 /**
  * Shows the MFL config.
  */
 function showMFLConfig() {
-    closeCurrentModal()
-    activeModal = "mflConfig"
-    document.getElementById("mflConfig").classList.add("is-active")
+    showModal("mflConfig")
 }
 
 /**
@@ -356,9 +366,7 @@ async function toggleTheme() {
  * Shows the hotkey config.
  */
 function showHotkeyConfig() {
-    closeCurrentModal()
-    activeModal = "hotkeyConfig"
-    document.getElementById("hotkeyConfig").classList.add("is-active")
+    showModal("hotkeyConfig")
 }
 
 // Handles the clipboard actions.
@@ -647,9 +655,7 @@ const optionWebviewBodge = option => {
  * Shows the uploader config page.
  */
 function showUploaderConfig() {
-    closeCurrentModal()
-    activeModal = "uploaderConfig"
-    document.getElementById("uploaderConfig").classList.add("is-active")
+    showModal("uploaderConfig")
 }
 
 // All of the imported uploaders.

--- a/src/gui/gui.js
+++ b/src/gui/gui.js
@@ -8,18 +8,22 @@
 let activeModal
 
 /**
- * Closes the active modal if there is one.
+ * Closes the active modal if there is one (and hides all others)
  */
 function closeCurrentModal() {
-    if (activeModal) {
+    // Find all active modals
+    const all = document.querySelectorAll(".modal.is-active")
+    all.forEach(div => {
         // Support custom close methods (Use a button with a delete class and onclick event to support this)
-        const del = document.getElementById(activeModal).querySelector("button.delete")
+        const del = div.querySelector("button.delete")
         if (del) del.click()
 
         // Assume normal closing
-        document.getElementById(activeModal).classList.remove("is-active")
-        activeModal = undefined
-    }
+        div.classList.remove("is-active")
+    })
+
+    // Remove activeModal if was set
+    if (activeModal) activeModal = undefined
 }
 
 // Allow devtools to be opened (placing this at the top just in case something breaks whilst loading)
@@ -101,9 +105,9 @@ document.head.appendChild(stylesheet)
 // Unhides the body/window when the page has loaded.
 window.onload = () => {
     // Register modal background click to close listeners
-    Array.from(document.getElementsByClassName("modal-background")).forEach(element => {
+    /* Array.from(document.getElementsByClassName("modal-background")).forEach(element => {
         element.addEventListener("click", closeCurrentModal)
-    })
+    }) */
 
     // Show the content
     document.body.style.display = "initial"
@@ -190,6 +194,7 @@ new Vue({
  * Shows the clipboard action settings page.
  */
 function showClipboardAction() {
+    closeCurrentModal()
     activeModal = "clipboardAction"
     document.getElementById("clipboardAction").classList.add("is-active")
 }
@@ -198,6 +203,7 @@ function showClipboardAction() {
  * Shows the beta updates settings page.
  */
 function showBetaUpdates() {
+    closeCurrentModal()
     activeModal = "betaUpdates"
     document.getElementById("betaUpdates").classList.add("is-active")
 }
@@ -245,6 +251,7 @@ async function runClipboardCapture() {
  * Shows the about page.
  */
 function showAbout() {
+    closeCurrentModal()
     activeModal = "about"
     document.getElementById("about").classList.add("is-active")
 }
@@ -270,6 +277,7 @@ function safeConfig() {
  * Shows the debug information page.
  */
 function showDebug() {
+    closeCurrentModal()
     // Generate debug information
     document.getElementById("debugInfo").textContent = `MagicCap Version: ${remote.app.getVersion()}
 System OS: ${os.type()} ${os.release()} / Platform: ${process.platform}
@@ -279,8 +287,6 @@ liteTouch Config: ${global.liteTouchConfig}`
     // Show
     activeModal = "debug"
     document.getElementById("debug").classList.add("is-active")
-    // Close about (that's how you get here)
-    document.getElementById("about").classList.remove("is-active")
 }
 
 /**
@@ -301,6 +307,7 @@ async function copyDebug() {
  * Shows the file config.
  */
 function showFileConfig() {
+    closeCurrentModal()
     activeModal = "fileConfig"
     document.getElementById("fileConfig").classList.add("is-active")
 }
@@ -309,6 +316,7 @@ function showFileConfig() {
  * Shows the MFL config.
  */
 function showMFLConfig() {
+    closeCurrentModal()
     activeModal = "mflConfig"
     document.getElementById("mflConfig").classList.add("is-active")
 }
@@ -348,6 +356,7 @@ async function toggleTheme() {
  * Shows the hotkey config.
  */
 function showHotkeyConfig() {
+    closeCurrentModal()
     activeModal = "hotkeyConfig"
     document.getElementById("hotkeyConfig").classList.add("is-active")
 }
@@ -638,6 +647,7 @@ const optionWebviewBodge = option => {
  * Shows the uploader config page.
  */
 function showUploaderConfig() {
+    closeCurrentModal()
     activeModal = "uploaderConfig"
     document.getElementById("uploaderConfig").classList.add("is-active")
 }

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -13,6 +13,12 @@
                 <aside class="menu">
                     <ul class="menu-list">
                         <li>
+                            <a href="javascript:closeCurrentModal()"
+                               data-tooltip="$View all your previous captures$"
+                               data-tooltip-position="right">
+                                <i class="far fa-images"></i> $Capture History$</a>
+                        </li>
+                        <li>
                             <a href="javascript:showAbout()"
                                data-tooltip="$View the version and authors$"
                                data-tooltip-position="right">

--- a/src/i18n/en/gui.po
+++ b/src/i18n/en/gui.po
@@ -1,3 +1,11 @@
+# gui/index.template.html:17
+msgid "View all your previous captures"
+msgstr ""
+
+# gui/index.template.html:19
+msgid "Capture History"
+msgstr ""
+
 # gui/index.template.html:16
 msgid "View the version and authors"
 msgstr ""


### PR DESCRIPTION
This pull request makes the following changes:
 - Internally, using a single function to open & close all modals
 - Within the UI, make modals feel more unified as part of the content & not web-like popups
 - Add a dedicated button to the sidebar that always goes back to the captures table, closing any active modal

| Before | After |
|-------|-------|
| ![image](https://user-images.githubusercontent.com/12371363/59555950-e591d080-8fb2-11e9-9bbe-63d299c89a7a.png) | ![image](https://user-images.githubusercontent.com/12371363/59555960-fd695480-8fb2-11e9-8d52-995bf455d902.png) |