### PR TITLE
Update button/tooltips styling, use system fonts & icons in captures table

### DIFF
--- a/src/gui/css/components/button.css
+++ b/src/gui/css/components/button.css
@@ -1,0 +1,10 @@
+/* This code is a part of MagicCap which is a MPL-2.0 licensed project.
+ * Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
+ */
+.button {
+    border-radius: .2em;
+    padding: 1em 1.5em;
+    font-weight: 600;
+    font-size: .9em;
+    transition: all .3s;
+}

--- a/src/gui/css/components/font.css
+++ b/src/gui/css/components/font.css
@@ -1,0 +1,6 @@
+/* This code is a part of MagicCap which is a MPL-2.0 licensed project.
+ * Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
+ */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}

--- a/src/gui/css/components/tooltip.css
+++ b/src/gui/css/components/tooltip.css
@@ -18,11 +18,13 @@
 [data-tooltip]:hover::after {
     content: attr(data-tooltip);
     position: absolute;
-    background: rgba(0, 0, 0, 0.9);
+    background: #161616;
     text-align: center;
     color: #fff;
     padding: 6px 4px;
     font-size: 14px;
+    line-height: 1;
+    vertical-align: middle;
     width: max-content;
     border-radius: 5px;
     pointer-events: none;
@@ -44,7 +46,7 @@
     transform: translateY(-50%);
     border-left-width: 0;
     border-right-width: 6px;
-    border-right-color: rgba(0, 0, 0, 0.9);
+    border-right-color: #161616;
 }
 
 [data-tooltip][data-tooltip-position="left"]:hover::after {
@@ -61,7 +63,7 @@
     transform: translateY(-50%);
     border-right-width: 0;
     border-left-width: 6px;
-    border-left-color: rgba(0, 0, 0, 0.9);
+    border-left-color: #161616;
 }
 
 [data-tooltip][data-tooltip-position="top"]:hover::after {
@@ -78,7 +80,7 @@
     transform: translateX(-50%);
     border-bottom-width: 0;
     border-top-width: 6px;
-    border-top-color: rgba(0, 0, 0, 0.9);
+    border-top-color: #161616;
 }
 
 [data-tooltip][data-tooltip-position="bottom"]:hover::after {
@@ -95,5 +97,5 @@
     transform: translateX(-50%);
     border-top-width: 0;
     border-bottom-width: 6px;
-    border-bottom-color: rgba(0, 0, 0, 0.9);
+    border-bottom-color: #161616;
 }

--- a/src/gui/css/main.css
+++ b/src/gui/css/main.css
@@ -1,9 +1,11 @@
 /* This code is a part of MagicCap which is a MPL-2.0 licensed project.
  * Copyright (C) Matt Cowley (MattIPv4) <me@mattcowley.co.uk> 2019.
  */
+@import "components/font.css";
 @import "components/base.css";
 @import "components/modal.css";
 @import "components/inputs.css";
 @import "components/menu.css";
 @import "components/tooltip.css";
+@import "components/button.css";
 @import "fontawesome-free/css/all.min.css";

--- a/src/gui/gui.js
+++ b/src/gui/gui.js
@@ -155,19 +155,11 @@ function getCaptures() {
 getCaptures();
 
 (async() => {
-    // Defines failure/success.
-    const i18nFailure = await i18n.getPoPhrase("Failure", "gui")
-    const i18nSuccess = await i18n.getPoPhrase("Success", "gui")
-
     // Handles the upload list.
     const mainTable = new Vue({
         el: "#mainTableBody",
         data: {
             captures: displayedCaptures,
-            successMap: [
-                i18nFailure,
-                i18nSuccess,
-            ],
         },
         methods: {
             rmCapture: async timestamp => {

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -102,7 +102,14 @@
                 <table class="table is-responsive is-fullwidth is-fullheight" id="mainTable">
                     <tbody id="mainTableBody">
                         <tr v-for="capture in captures" :key="capture.timestamp">
-                            <td>{{ successMap[capture.success] }}</td>
+                            <td v-if="capture.success === 0">
+                                <span data-tooltip="$Capture failed$" data-tooltip-position="right">
+                                    <i class="fas fa-times"></i></span>
+                            </td>
+                            <td v-else>
+                                <span data-tooltip="$Capture successful$" data-tooltip-position="right">
+                                    <i class="fas fa-check"></i></span>
+                            </td>
                             <td>{{ capture.filename }}</td>
                             <td>{{ new Date(capture.timestamp).toLocaleString() }}</td>
                             <td v-if="capture.url === undefined"></td>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -262,7 +262,10 @@
                     <p>$Copyright (C) Jake Gealer, Rhys O'Kane & Matt Cowley 2018-2019.$</p>
                     <p>$This software is licensed under the {license} license.$</p>
                     <p v-if="liteTouch">$Some settings are managed by your system administrator.$</p>
-                    <p><br/><small><a href="javascript:showDebug()">$Debug Information$</a></small></p>
+                    <p>
+                        <br/>
+                        <small><a class="button is-small" href="javascript:showDebug()">$Debug Information$</a></small>
+                    </p>
                 </section>
             </div>
         </div>

--- a/src/i18n/en/gui.po
+++ b/src/i18n/en/gui.po
@@ -245,12 +245,12 @@ msgstr ""
 msgid "this documentation"
 msgstr ""
 
-# gui/gui.js:44
-msgid "Failure"
+# gui/gui.js:100
+msgid "Capture failed"
 msgstr ""
 
-# gui/gui.js:45
-msgid "Success"
+# gui/gui.js:104
+msgid "Capture successful"
 msgstr ""
 
 # gui/index.template.html:86


### PR DESCRIPTION
This pull request intends to make the following changes:
 - Provide a proper button on the about modal for debug information
 - Update the styling of tooltips to use a non-transparent background to fit the app design better
 - Use the native system font stack for the application in both light & dark themes
 - Update the design of the buttons to waste less vertical space and appear cleaner
 - Replace the "Failure/Success" messages on the captures table with icons (they have tooltips with messages) to reclaim some horizontal space