### PR TITLE
Update sidebar mostly

### DIFF
--- a/src/gui/css/components/base.css
+++ b/src/gui/css/components/base.css
@@ -33,6 +33,10 @@ html, body {
     border-radius: 50%;
 }
 
+.columns {
+    margin: 0 !important;
+}
+
 .columns > .column {
     min-height: 100vh;
 }

--- a/src/gui/css/components/base.css
+++ b/src/gui/css/components/base.css
@@ -37,6 +37,7 @@ html, body {
     background: transparent;
     position: fixed;
     width: 15%;
+    z-index: 10;
 }
 
 .column.aside + .column {

--- a/src/gui/css/components/base.css
+++ b/src/gui/css/components/base.css
@@ -33,6 +33,10 @@ html, body {
     border-radius: 50%;
 }
 
+.columns > .column {
+    min-height: 100vh;
+}
+
 .column.aside {
     background: transparent;
     position: fixed;

--- a/src/gui/css/components/modal.css
+++ b/src/gui/css/components/modal.css
@@ -14,7 +14,6 @@
 }
 
 .modal .modal-card-body hr {
-    background: #4c5759;
     margin: 1rem 0;
 }
 

--- a/src/gui/css/components/modal.css
+++ b/src/gui/css/components/modal.css
@@ -4,7 +4,7 @@
 
 .modal {
     margin: 0 0 0 15%;
-    z-index: -1; /* Allow tooltips in sidebar to work */
+    z-index: 0; /* Allow tooltips in sidebar to work */
 }
 
 .modal .modal-card {

--- a/src/gui/css/dark.css
+++ b/src/gui/css/dark.css
@@ -30,6 +30,10 @@ body {
     color: #fff;
 }
 
+hr {
+    background: rgba(255, 255, 255, 0.2);
+}
+
 .column,
 .modal-background,
 .modal-card-foot,

--- a/src/gui/css/light.css
+++ b/src/gui/css/light.css
@@ -30,6 +30,10 @@ body {
     color: #343434;
 }
 
+hr {
+    background: rgba(0, 0, 0, 0.2);
+}
+
 .column,
 .modal-background,
 .modal-card-foot,

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -18,12 +18,6 @@
                                data-tooltip-position="right">
                                 <i class="far fa-images"></i> $Capture History$</a>
                         </li>
-                        <li>
-                            <a href="javascript:showAbout()"
-                               data-tooltip="$View the version and authors$"
-                               data-tooltip-position="right">
-                                <i class="fas fa-info"></i> $About$</a>
-                        </li>
                         <li v-if="clipboardAction">
                             <a href="javascript:showClipboardAction()"
                                data-tooltip="$Control what will be on your clipboard after capture$"
@@ -47,6 +41,15 @@
                                data-tooltip="$Enable uploading captures and configure the upload target$"
                                data-tooltip-position="right">
                                 <i class="fas fa-upload"></i> $Uploader Settings$</a>
+                        </li>
+
+                        <li><hr/></li>
+
+                        <li>
+                            <a href="javascript:showAbout()"
+                               data-tooltip="$View the version and authors$"
+                               data-tooltip-position="right">
+                                <i class="fas fa-info"></i> $About$</a>
                         </li>
                         <li v-if="betaUpdates">
                             <a href="javascript:showBetaUpdates()"

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -6,7 +6,7 @@
     </head>
 
     <body style="display: none">
-        <div class="columns is-gapless" style="margin: 0;">
+        <div class="columns is-gapless">
 
             <!-- The sidebar menu -->
             <aside class="column aside" id="sidebar">
@@ -180,7 +180,7 @@
                             </div>
                             <div v-else-if="option.type === 'token_from_json'">
                                 <div class="field">
-                                    <label class="label" :for="option.value">{{ option.translatedName }}:</label>
+                                    <label class="label
                                     <div v-if="getDefaultValue(option) === undefined">
                                         <webview :id="option.value" :src="option.startUrl" :useragent="userAgent" style="height: 450px"></webview>
                                     </div>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -9,7 +9,7 @@
         <div class="columns is-gapless" style="margin: 0;">
 
             <!-- The sidebar menu -->
-            <aside class="column is-2 aside hero is-fullheight" id="sidebar">
+            <aside class="column aside" id="sidebar">
                 <aside class="menu">
                     <ul class="menu-list">
                         <li>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -115,13 +115,13 @@
                             </td>
                             <td>{{ capture.filename }}</td>
                             <td>{{ new Date(capture.timestamp).toLocaleString() }}</td>
-                            <td v-if="capture.url === undefined"></td>
-                            <td v-else>
+                            <td v-if="capture.url">
                                 <a v-on:click="openScreenshotURL(capture.url)" class="url">{{ capture.url }}</a>
                             </td>
+                            <td v-else></td>
                             <td v-if="capture.success === 0"></td>
                             <td v-else>
-                                    <a class="button is-primary" v-on:click="openScreenshotFile(capture.file_path ? capture.file_path : capture.url)">$View$</a>
+                                <a class="button is-primary" v-on:click="openScreenshotFile(capture.file_path ? capture.file_path : capture.url)">$View$</a>
                             </td>
                             <td>
                                 <a class="button is-danger" v-on:click="rmCapture(capture.timestamp)">$Remove$</a>


### PR DESCRIPTION
This pull request intends to make the following changes:
 - Re-order the sidebar to create a new section for "app" items (move about down)
 - Make the horizontal breaks in the sidebar more noticeable and match the theme
 - Force all columns of the app (captures table) to always be full height
 - Resolve tooltips being hidden when modals are showing